### PR TITLE
Rename File.exists? to File.exist? for ruby 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,16 @@ Fetch Root CA certificates from Windows system store.
 
 ## Abstract
 
-Default installation of Ruby on Microsoft Windows provides no root certificates at all.
-Secure connections are simply impossible.
+Default installation of Ruby on Microsoft Windows used to provide no root certificates at all.
+Secure connections were simply impossible. 
 
 Recommended fix is to load http://curl.haxx.se/ca/cacert.pem
 and set SSL_CERT_FILE environment variable.
+
+[Ruby Installer provides cacert.pem since Version 2.4.](https://github.com/oneclick/rubyinstaller2/issues/8)
+[However that certificate file is not automatically updated.](https://github.com/oneclick/rubyinstaller2/blob/9017818c301aa92041a647e16421c3a9d62fe1bc/resources/ssl/README-SSL.md)
+Since the cacert.pem was downloaded when the ruby installer version was published, new root certificates could be missing.
+
 
 But Windows has its own certificate store.
 This gem just access it,
@@ -69,6 +74,12 @@ or via `-CApath` argument of `openssl` command.
   * [Win-Ca][] for [Node.js][]
   * [Rufus::Lua::Win][]
   * [Ruby on Windows][] Book
+
+
+## Caution
+
+On Windows Server, there are cases were the Windows Certificate Store has not activated a certificate. 
+The workaround is to first load the site with a (microsoft) browser or make a WinHttpRequest with win32ole. This somehow forces the certificate store to activate the parent root certificate.
 
 ## Credits
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,9 @@ cache:
 
 environment:
   matrix:
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 22
-    - RUBY_VERSION: 21
-    - RUBY_VERSION: 200
+    - RUBY_VERSION: 27
+    - RUBY_VERSION: 31
+    - RUBY_VERSION: 32
 
 platform:
   - x64

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,3 +1,0 @@
-task :default do
-  require File.expand_path '../../lib/openssl/win/root', __FILE__
-end

--- a/lib/openssl/win/root.rb
+++ b/lib/openssl/win/root.rb
@@ -44,7 +44,7 @@ module OpenSSL::Win::Root
   def self.path
     return @path if @path
     x = File.expand_path '..', __FILE__
-    x = File.dirname x until File.exists? File.join x, 'Gemfile'
+    x = File.dirname x until File.exist? File.join x, 'Gemfile'
     x = File.join x, 'pem'
     FileUtils.mkdir_p x
     @path = x

--- a/lib/openssl/win/root.rb
+++ b/lib/openssl/win/root.rb
@@ -87,8 +87,7 @@ Saved:   #{Time.now} by #{self} v#{VERSION}
         EOT
       end
       link = File.join path, cr.name(crt.subject.hash_old)
-      File.unlink link rescue nil
-      File.link name, link
+      FileUtils.ln name, link, force: true
     end
     Dir.glob File.join path, '*' do |f|
       File.unlink f rescue nil unless cr.names[File.basename f]

--- a/lib/openssl/win/root/version.rb
+++ b/lib/openssl/win/root/version.rb
@@ -1,7 +1,7 @@
 module OpenSSL
   module Win
     module Root
-      VERSION = "1.1.1"
+      VERSION = "1.1.2"
     end
   end
 end

--- a/openssl-win-root.gemspec
+++ b/openssl-win-root.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.extensions    = ['ext/mkrf_conf.rb']
+  spec.extensions    = []
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This function got removed in ruby 3.2. I prefered the exists syntax as well, but the gem is broken now like this.